### PR TITLE
feat: reject promises with errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lute-connect",
-  "version": "1.0.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lute-connect",
-      "version": "1.0.4",
+      "version": "1.2.0",
       "license": "ISC",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",


### PR DESCRIPTION
## Description

This improves the way promises are rejected within the library by using `Error` instances instead of plain objects. This adheres to JavaScript best practices and helps with debugging by including a stack trace along with the message.

In the `connect` method, promises are rejected with a normal `Error`

```ts
reject(new Error("Operation Canceled"));
```

In the `signTxns` method, promises are rejected with a refactored `SignTxnsError` that includes the `code`

```ts
export class SignTxnsError extends Error {
  code: number;
  data?: any;

  constructor(message: string, code: number, data?: any) {
    super(message);
    this.name = 'SignTxnsError';
    this.code = code;
    this.data = data;
  }
}

// ...

reject(new SignTxnsError(event.data.message, event.data.code || 4300));
```

Another advantage of making `SignTxnsError` a class is that you can check for it with `instanceof` in a catch block, e.g.,

```ts
try {
  // ...
} catch (error: any) {
  console.error(
    `[LuteWallet] Error signing transactions: ` +
      (error instanceof SignTxnsError ? `${error.message} (code: ${error.code})` : error.message)
  )
  throw error
}
```

### Other Changes

- The package-lock.json file was still showing on outdated version, `1.0.4`. This updates it to match the version in package.json, `1.2.0`